### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/src/Hoist/Hoist.csproj
+++ b/src/Hoist/Hoist.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Docker.Registry.Client" Version="0.0.0-preview.0.77" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />

--- a/src/Hoist/Hoist.csproj
+++ b/src/Hoist/Hoist.csproj
@@ -15,8 +15,9 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="Spectre.Cli.Extensions.DependencyInjection" Version="0.4.0" />
-        <PackageReference Include="Spectre.Console" Version="0.44.0" />
+        <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
+        <PackageReference Include="Spectre.Console" Version="0.45.0" />
+        <PackageReference Include="Spectre.Console.CLi" Version="0.45.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Hoist/Program.cs
+++ b/src/Hoist/Program.cs
@@ -4,7 +4,7 @@ using Hoist.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli.Extensions.DependencyInjection;
+using Spectre.Console.Cli.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 
 var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
Spectre.Console has removed CLI functions into its own Spectre.Console.Cli NuGet package, this PR addresses the changes needed to be able to adopt the latest Spectre.Console version.

* Update Spectre.Console to 0.45.0
* Add Spectre.Console.Cli 0.45.0
* Migrate from Spectre.Cli.Extensions.DependencyInjection to Spectre.Console.Cli.Extensions.DependencyInjection